### PR TITLE
NI Berlin Concert Grand Fixes.

### DIFF
--- a/src/winetricks
+++ b/src/winetricks
@@ -13377,19 +13377,19 @@ load_berlin_concert_grand()
   [ ! -r "$W_CACHE/$W_PACKAGE/Berlin_Concert_Grand.iso" ] && w_warn "File '$W_CACHE/$W_PACKAGE/Berlin_Concert_Grand.iso' is not readable, this is usually indication of NTFS-based filesystem and so we will need to correct this using 'chmod' for which we try to elevate root"
 
   [ ! -r "$W_CACHE/$W_PACKAGE/Berlin_Concert_Grand.iso" ] && { "$WINETRICKS_SUDO" chmod +r "$W_CACHE/$W_PACKAGE/Berlin_Concert_Grand.iso" || w_die "Unable to set readable permission on '$W_CACHE/$W_PACKAGE/Berlin_Concert_Grand.iso' set this manually, i.e; 'chmod +r path'" ;}
-
-  [ ! -r "$W_CACHE/$W_PACKAGE/berlin_concert_grand/Berlin Concert Grand 1.3.0 Installer Mac.pkg" ] && { "$WINETRICKS_SUDO" chmod +r "$W_CACHE/$W_PACKAGE/Berlin_Concert_Grand.iso" || w_die "Unable to set readable permission on '$W_CACHE/$W_PACKAGE/Berlin_Concert_Grand.iso' set this manually, i.e; 'chmod +r path'" ;}
-
-  [ ! -r "$W_CACHE/$W_PACKAGE/berlin_concert_grand/Berlin Concert Grand 1.3.0 Setup PC.exe" ] && { "$WINETRICKS_SUDO" chmod +r "$W_CACHE/$W_PACKAGE/berlin_concert_grand/Berlin Concert Grand 1.3.0 Setup PC.exe" || w_die "Unable to set readable permission on '$W_CACHE/$W_PACKAGE/berlin_concert_grand/Berlin Concert Grand 1.3.0 Setup PC.exe' set this manually, i.e; 'chmod +r path'" ;}
-
-  [ ! -r "$W_CACHE/$W_PACKAGE/berlin_concert_grand/Berlin Concert Grand Library Part 1.pkg" ] && { "$WINETRICKS_SUDO" chmod +r "$W_CACHE/$W_PACKAGE/berlin_concert_grand/Berlin Concert Grand Library Part 1.pkg" || w_die "Unable to set readable permission on '$W_CACHE/$W_PACKAGE/berlin_concert_grand/Berlin Concert Grand Library Part 1.pkg' set this manually, i.e; 'chmod +r path'" ;}
-
-  [ ! -r "$W_CACHE/$W_PACKAGE/berlin_concert_grand/Berlin Concert Grand Library Part 2.pkg" ] && { "$WINETRICKS_SUDO" chmod +r "$W_CACHE/$W_PACKAGE/berlin_concert_grand/Berlin Concert Grand Library Part 2.pkg" || w_die "Unable to set readable permission on '$W_CACHE/$W_PACKAGE/berlin_concert_grand/Berlin Concert Grand Library Part 2.pkg' set this manually, i.e; 'chmod +r path'" ;}
-
-  [ ! -r "$W_CACHE/$W_PACKAGE/berlin_concert_grand/Berlin Concert Grand Library Part 3.pkg" ] && { "$WINETRICKS_SUDO" chmod +r "$W_CACHE/$W_PACKAGE/berlin_concert_grand/Berlin Concert Grand Library Part 3.pkg" || w_die "Unable to set readable permission on '$W_CACHE/$W_PACKAGE/berlin_concert_grand/Berlin Concert Grand Library Part 3.pkg' set this manually, i.e; 'chmod +r path'" ;}
-
+  
   # Extract the ISO
   [ ! -e "$W_CACHE/$W_PACKAGE/Berlin Concert Grand 1.3.0 Setup PC.exe" ] && { w_try_7z "$W_CACHE/$W_PACKAGE/" "$W_CACHE/$W_PACKAGE/$file1" ;} || printf '%s\n' "File '$W_CACHE/$W_PACKAGE/Berlin_Concert_Grand.iso' already exists"
+
+  [ ! -r "$W_CACHE/$W_PACKAGE/Berlin Concert Grand 1.3.0 Installer Mac.pkg" ] && { "$WINETRICKS_SUDO" chmod +r "$W_CACHE/$W_PACKAGE/Berlin_Concert_Grand.iso" || w_die "Unable to set readable permission on '$W_CACHE/$W_PACKAGE/Berlin_Concert_Grand.iso' set this manually, i.e; 'chmod +r path'" ;}
+
+  [ ! -r "$W_CACHE/$W_PACKAGE/Berlin Concert Grand 1.3.0 Setup PC.exe" ] && { "$WINETRICKS_SUDO" chmod +r "$W_CACHE/$W_PACKAGE/Berlin Concert Grand 1.3.0 Setup PC.exe" || w_die "Unable to set readable permission on '$W_CACHE/$W_PACKAGE/Berlin Concert Grand 1.3.0 Setup PC.exe' set this manually, i.e; 'chmod +r path'" ;}
+
+  [ ! -r "$W_CACHE/$W_PACKAGE/Berlin Concert Grand Library Part 1.pkg" ] && { "$WINETRICKS_SUDO" chmod +r "$W_CACHE/$W_PACKAGE/Berlin Concert Grand Library Part 1.pkg" || w_die "Unable to set readable permission on '$W_CACHE/$W_PACKAGE/Berlin Concert Grand Library Part 1.pkg' set this manually, i.e; 'chmod +r path'" ;}
+
+  [ ! -r "$W_CACHE/$W_PACKAGE/Berlin Concert Grand Library Part 2.pkg" ] && { "$WINETRICKS_SUDO" chmod +r "$W_CACHE/$W_PACKAGE/Berlin Concert Grand Library Part 2.pkg" || w_die "Unable to set readable permission on '$W_CACHE/$W_PACKAGE/Berlin Concert Grand Library Part 2.pkg' set this manually, i.e; 'chmod +r path'" ;}
+
+  [ ! -r "$W_CACHE/$W_PACKAGE/Berlin Concert Grand Library Part 3.pkg" ] && { "$WINETRICKS_SUDO" chmod +r "$W_CACHE/$W_PACKAGE/Berlin Concert Grand Library Part 3.pkg" || w_die "Unable to set readable permission on '$W_CACHE/$W_PACKAGE/Berlin Concert Grand Library Part 3.pkg' set this manually, i.e; 'chmod +r path'" ;}
 
   # Execute
   w_try "$WINE" "$W_CACHE/$W_PACKAGE/Berlin Concert Grand 1.3.0 Setup PC.exe"


### PR DESCRIPTION
Reordered winetricks commands so extraction happens before permissions checks.
I also had to fix some of the file paths because there was an extra `berlin_concert_grand` directory in there.

It's working now, thanks for the help Kreyren. I learned a thing or two about wine/winetricks. =]