### PR TITLE
Phoenix Maple Story: Help wanted

### DIFF
--- a/src/winetricks
+++ b/src/winetricks
@@ -19258,6 +19258,35 @@ load_hordesoforcs2_demo()
 
 #----------------------------------------------------------------
 
+# Upstream mensiones vcrun2015 dependency (https://playphoenix.ca/downloads)
+# Blocked by https://bugs.winehq.org/show_bug.cgi?id=4666
+
+w_metadata maplestory_phoenix games \
+    title="Phoenix Maple Story" \
+    publisher="?" \
+    year="?" \
+    media="download" \
+    file1="Phoenix-11-22-19.zip"
+    #installed_exe1="$W_PROGRAMS_X86_WIN/Wizards of the Coast/MTGA/MTGA.exe"
+
+load_maplestory_phoenix()
+{
+    if w_workaround_wine_bug 4666; then
+        w_die fixme "Verb $W_PACKAGE is blocked by winebug 4666 (https://bugs.winehq.org/show_bug.cgi?id=4666)"
+    elif ! w_workaround_wine_bug 4666; then
+        w_download https://playphoenix.ca/Phoenix-11-22-19.zip
+        w_extractor "$W_CACHE/$W_PACKAGE/$file1" "$WINEPREFIX/drive_c/"
+
+        "$WINE" "$WINEPREFIX/drive_c/Phoenix/MapleStory.exe"
+
+        case $? in
+            *) w_warn "File MapleStory.exe returned error code $? which is unknown to winetricks, if you encounter this message then please make a new issue"
+        esac
+    fi
+}
+
+#----------------------------------------------------------------
+
 # https://appdb.winehq.org/objectManager.php?sClass=version&iId=37229
 
 w_metadata mtg_arena games \


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/11302521/69499904-1e858800-0ef7-11ea-84d2-4affaaff4240.png)

This seems to be blocked by https://bugs.winehq.org/show_bug.cgi?id=4666 (Not confirmed that it's using said anti-cheat)

Based on https://bugs.winehq.org/show_bug.cgi?id=4666#c59 winehq in process of exporting winelibs as Portable Executables which might help with the solution.

Upstream mensiones vcrun2015 dependency:
<img width="508" alt="image" src="https://user-images.githubusercontent.com/11302521/69499892-fac24200-0ef6-11ea-9d81-fb754d8c1557.png">

log: (dotnet462+vcrun2015): https://gist.githubusercontent.com/Kreyren/91ee18028f3c79d6a3882cb298608d0f/raw/e62af4e043a1a81ca2cb77ca316b26c4019ccbd5/gistfile1.txt

Fixes: https://github.com/Kreytricks/kreytricks/issues/51